### PR TITLE
Add new allocator: Public Open Dataset Pathway

### DIFF
--- a/Allocators/recplu9tx3AHX3s1a.json
+++ b/Allocators/recplu9tx3AHX3s1a.json
@@ -1,0 +1,41 @@
+{
+  "address": "f2gf2at3tv5mtv7cbkq6lh3ptgzz4aju5fweciyaq",
+  "name": "Public Open Dataset Pathway",
+  "allocator_id": "f03015751",
+  "organization": "Data Preservation Institute",
+  "metapathway_type": "MA",
+  "ma_address": "0x15a9d9b81e3c67b95ffedfb4416d25a113c8c6df",
+  "associated_org_addresses": "f2gf2at3tv5mtv7cbkq6lh3ptgzz4aju5fweciyaq",
+  "application": {
+    "audit": [
+      "Public Open "
+    ],
+    "distribution": [
+      "Equal distribution of deals across regions"
+    ],
+    "required_sps": "1",
+    "required_replicas": "2",
+    "tooling": [],
+    "github_handles": [
+      "asynctomatic",
+      "damipud",
+      "willscott"
+    ],
+    "client_contract_address": ""
+  },
+  "status": {},
+  "LifeCycle": {
+    "Audit 1": [
+      "1746651642247",
+      "5"
+    ]
+  },
+  "pathway_addresses": {
+    "msig": "f2gf2at3tv5mtv7cbkq6lh3ptgzz4aju5fweciyaq",
+    "signer": [
+      "f1k4zrriujtwdlea64k7saa3l7jkbatzebfzinj7i",
+      "f1r3lzgzpja2hvhcaxcdruic5qol2as27jl52xtvq",
+      "f1msap4wvgzzv4xlzeq6kycmgx55ferfloxnt2rcy"
+    ]
+  }
+}


### PR DESCRIPTION
# Filecoin Plus Allocator Application

## Application Details
| Field | Value |
|-------|-------|
| Applicant | Public Open Dataset Pathway |
| Organization | Data Preservation Institute |
| Address | [f2gf2at3tv5mtv7cbkq6lh3ptgzz4aju5fweciyaq](https://filfox.info/en/address/f2gf2at3tv5mtv7cbkq6lh3ptgzz4aju5fweciyaq) |
| GitHub Username | [![GitHub](https://img.shields.io/badge/GitHub-asynctomatic?style=flat-square&logo=github)](https://github.com/asynctomatic) |

## Grant Details
| Field | Value |
|-------|-------|
| DataCap Amount | 5 PiB |
| Allocation Method | META_ALLOCATOR |

---
<sup>This message was automatically generated by the Filecoin Plus Bot. For more information, visit [filecoin.io](https://filecoin.io)</sup>